### PR TITLE
Fix typos: "projecto"

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Para ejecutar el proyecto es necesario tener:
  ```docker``` y ```docker-compose``` ([como instalar Docker](https://docs.docker.com/install/))
 
 ## Ejecutar ejemplo
-Con el código fuente del proyecto en tu computador, puedes ejecutar en la raíz del proyecto el comando para construir el contenedor docker, si es la primera vez que ejecutas el projecto:
+Con el código fuente del proyecto en tu computador, puedes ejecutar en la raíz del proyecto el comando para construir el contenedor docker, si es la primera vez que ejecutas el proyecto:
 ```bash
 docker-compose build
 ```
@@ -17,7 +17,7 @@ Luego, es necesario instalar las dependencias:
 ```bash
 docker-compose run web bundle install
 ```
-Finalmente, para correr el projecto de ejemplo:
+Finalmente, para correr el proyecto de ejemplo:
 ```
 docker-compose run --rm --service-ports web
 ```


### PR DESCRIPTION
- Change several instances of the word "projecto", to the correct
spanish word, "proyecto"